### PR TITLE
Find any bugs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import GoogleSheetsProvider from 'react-db-google-sheets';
 import Layout from './components/Layout';
 import Home from './components/Home';
 import About from './components/About';
 import Resources from './components/Resources';
-import Mediators from './components/Mediators';
-import Contact from './components/Contact';
+// import Contact from './components/Contact';
 
 import './App.scss';
+
+const Mediators = lazy(() => import('./components/Mediators'));
+const Contact = lazy(() => import('./components/Contact'));
 
 function App() {
   const config = {
@@ -19,15 +21,17 @@ function App() {
 
   return (
     <GoogleSheetsProvider config={config}>
-      <Routes> 
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Home />} />
-          <Route path="about" element={<About />} />
-          <Route path="resources" element={<Resources />} />
-          <Route path="mediators" element={<Mediators />} />
-          <Route path="contact" element={<Contact />} />
-        </Route>
-      </Routes>
+      <Suspense fallback={null}>
+        <Routes> 
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Home />} />
+            <Route path="about" element={<About />} />
+            <Route path="resources" element={<Resources />} />
+            <Route path="mediators" element={<Mediators />} />
+            <Route path="contact" element={<Contact />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </GoogleSheetsProvider>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import React from 'react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('react-db-google-sheets', () => ({
+  __esModule: true,
+  default: ({ children }) => <>{children}</>,
+  withGoogleSheets: () => (Component) => (props) => (
+    <Component {...props} db={{ resources: [], mediators: [] }} />
+  ),
+}));
+
+it('renders Home description text', () => {
+  render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  );
+  expect(screen.getByText(/Find conflict mediators/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
Fix Jest test failures by lazy-loading components and updating test mocks.

Tests were failing due to two main issues:
1.  **ESM in `react-leaflet`**: The `Mediators` component, which imports `react-leaflet` (an ESM module), was causing Jest to error during test parsing. Lazy-loading `Mediators` and `Contact` components, wrapped in `Suspense`, defers their import until runtime, bypassing this issue in tests.
2.  **`GoogleSheetsProvider` blocking render**: The `GoogleSheetsProvider` was rendering a loading state in tests, preventing the actual content from being asserted. Mocking `react-db-google-sheets` ensures the provider immediately renders its children and injects a stub `db` prop, allowing tests to proceed.
Additionally, the `App.test.js` was updated to assert actual content from the `Home` component and wrapped with `BrowserRouter` for proper routing context.

---
<a href="https://cursor.com/background-agent?bcId=bc-896506d2-6e6e-4ada-aeb9-74d542b1aa10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-896506d2-6e6e-4ada-aeb9-74d542b1aa10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

