### PR TITLE
refactor: extract theme logic to hook

### DIFF
--- a/src/components/ThemeToggle/index.js
+++ b/src/components/ThemeToggle/index.js
@@ -1,37 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+import useTheme from '../../hooks/useTheme';
 import './index.scss';
 
 const ThemeToggle = ({ className = '', fixed = true }) => {
-    const [isDark, setIsDark] = useState(false);
-
-    useEffect(() => {
-        // Check for saved theme preference or default to light
-        const savedTheme = localStorage.getItem('theme');
-        const mql = window.matchMedia
-            ? window.matchMedia('(prefers-color-scheme: dark)')
-            : null;
-        const prefersDark = mql ? mql.matches : false;
-
-        if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
-            setIsDark(true);
-            document.documentElement.setAttribute('data-theme', 'dark');
-        }
-    }, []);
-
-    const toggleTheme = () => {
-        const newTheme = !isDark;
-        setIsDark(newTheme);
-
-        if (newTheme) {
-            document.documentElement.setAttribute('data-theme', 'dark');
-            localStorage.setItem('theme', 'dark');
-        } else {
-            document.documentElement.removeAttribute('data-theme');
-            localStorage.setItem('theme', 'light');
-        }
-    };
+    const { isDark, toggleTheme } = useTheme();
 
     const classes = `theme-toggle btn btn--ghost btn--icon ${
         fixed ? 'theme-toggle--fixed' : ''

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+
+const useTheme = () => {
+    const [isDark, setIsDark] = useState(false);
+
+    useEffect(() => {
+        const savedTheme = localStorage.getItem('theme');
+        const mql = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+        const prefersDark = mql ? mql.matches : false;
+
+        if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+            setIsDark(true);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (isDark) {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            localStorage.setItem('theme', 'dark');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.setItem('theme', 'light');
+        }
+    }, [isDark]);
+
+    const toggleTheme = () => setIsDark(prev => !prev);
+
+    return { isDark, toggleTheme };
+};
+
+export default useTheme;


### PR DESCRIPTION
## Summary
- add reusable `useTheme` hook for managing light/dark mode and persistence
- simplify `ThemeToggle` component to use new hook

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad196c51848327b1e0e7fe359799c3