### PR TITLE
style: add green toast variant

### DIFF
--- a/src/components/UI/Toast.scss
+++ b/src/components/UI/Toast.scss
@@ -51,3 +51,44 @@
   }
 }
 
+/* Variant styles */
+.toast--success {
+  background: var(--success-50);
+  color: var(--success-700);
+  border-left: 4px solid var(--success-500);
+}
+
+.toast__icon--success {
+  color: var(--success-500);
+}
+
+.toast--error {
+  background: var(--danger-50);
+  color: var(--danger-700);
+  border-left: 4px solid var(--danger-500);
+}
+
+.toast__icon--error {
+  color: var(--danger-500);
+}
+
+.toast--warning {
+  background: var(--warning-50);
+  color: var(--warning-700);
+  border-left: 4px solid var(--warning-500);
+}
+
+.toast__icon--warning {
+  color: var(--warning-500);
+}
+
+.toast--info {
+  background: var(--info-50);
+  color: var(--info-700);
+  border-left: 4px solid var(--info-500);
+}
+
+.toast__icon--info {
+  color: var(--info-500);
+}
+


### PR DESCRIPTION
## Summary
- style toast component with semantic color variants
- add success green styling back for toast notifications

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad204751448327a31e4a7216cfe60f